### PR TITLE
Fix `isExpired` dates comparison logic

### DIFF
--- a/JWTWrapper/JWT.swift
+++ b/JWTWrapper/JWT.swift
@@ -143,7 +143,7 @@ public struct JWT: CustomStringConvertible, CustomDebugStringConvertible {
     //Computed properties
     public var isExpired: Bool {
         if let expDate = expirationDate {
-            return expDate > Date()
+            return expDate < Date()
         }
         return false
     }


### PR DESCRIPTION
Dates were comparing in a wrong way so the `isExpired` flag was `false` when it actually was `true`.